### PR TITLE
Invert rss colors in aakb and dokk1 theme

### DIFF
--- a/src/themes/aakb.css
+++ b/src/themes/aakb.css
@@ -124,9 +124,15 @@
 */
 
 #SLIDE_ID .template-rss {
+  --text-color: var(--text-light, hsl(0deg, 0%, 100%));
   padding: calc(var(--spacer) * 4);
   gap: calc(var(--spacer) * 6);
   background-color: var(--color-primary);
+  color: var(--text-color);
+}
+
+.color-scheme-dark #SLIDE_ID .template-rss {
+  --text-color: var(--text-dark, hsl(0deg, 0%, 0%));
 }
 
 #SLIDE_ID .template-rss .feed-info {

--- a/src/themes/dokk1.css
+++ b/src/themes/dokk1.css
@@ -199,10 +199,15 @@
 */
 
 #SLIDE_ID .template-rss {
+  --text-color: var(--text-light, hsl(0deg, 0%, 100%));
   padding: calc(var(--spacer) * 4);
   gap: calc(var(--spacer) * 6);
-  --text-color: white;
   background-color: var(--color-primary);
+  color: var(--text-color);
+}
+
+.color-scheme-dark #SLIDE_ID .template-rss {
+  --text-color: var(--text-dark, hsl(0deg, 0%, 0%));
 }
 
 #SLIDE_ID .template-rss .feed-info--date {


### PR DESCRIPTION
Invert light/dark text colors in dokk1.css and aakb.css themes for rss templates.