### PR TITLE
Hotfix: Add tags to config routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [2.1.1] - 2024-12-09
+
 - [#162](https://github.com/os2display/display-templates/pull/162)
   - Added option to build main config files with a tag from DEPLOYMENT_BUILD_TAG.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- [#TODO](https://github.com/os2display/display-templates/pull/TODO)
+- [#162](https://github.com/os2display/display-templates/pull/162)
   - Added option to build main config files with a tag from DEPLOYMENT_BUILD_TAG.
 
 ## [2.1.0] - 2024-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [2.1.0] - 2024-10-23
 
+- [#TODO](https://github.com/os2display/display-templates/pull/TODO)
+  - Added option to build main config files with a tag from DEPLOYMENT_BUILD_TAG.
 - [#158](https://github.com/os2display/display-templates/pull/158)
   - Expanded documentation for new templates.
 - [#157](https://github.com/os2display/display-templates/pull/157)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.0] - 2024-10-23
+## Unreleased
 
 - [#TODO](https://github.com/os2display/display-templates/pull/TODO)
   - Added option to build main config files with a tag from DEPLOYMENT_BUILD_TAG.
+
+## [2.1.0] - 2024-10-23
+
 - [#158](https://github.com/os2display/display-templates/pull/158)
   - Expanded documentation for new templates.
 - [#157](https://github.com/os2display/display-templates/pull/157)

--- a/README.md
+++ b/README.md
@@ -7,22 +7,21 @@ See [https://github.com/os2display/display-docs/blob/main/templates.md](https://
 
 When creating a release the config files should be built with a tag in the config routes.
 
+Follow the instructions below.
+
+Replace `<TAG>` with the given tag.
+
 ```shell
-git checkout develop
-git pull
-git checkout -b release/<<TAG>>
-docker compose run --rm --env DEPLOYMENT_BUILD_TAG=${<<TAG>>} node yarn build
-git checkout build/*-develop.json
+# Create the release branch: release/<TAG>
 
-# Update CHANGELOG with new tag.
-nano CHANGELOG.md
+# Build the js and config files with tags in main config files.
+docker compose run --rm --env DEPLOYMENT_BUILD_TAG=<TAG> node yarn build
 
-git add .
-git commit -m "Built release <<TAG>>"
-git push
+# Update CHANGELOG with the new tag.
+# When ready merge release branch in main.
+# Tag the release in main
+# Merge main in develop
 ```
-
-
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 Contains base templates for OS2Display.
 See [https://github.com/os2display/display-docs/blob/main/templates.md](https://github.com/os2display/display-docs/blob/main/templates.md) for a description of how to create templates.
 
+## Release
+
+When creating a release the config files should be built with a tag in the config routes.
+
+```shell
+git checkout develop
+git pull
+git checkout -b release/<<TAG>>
+docker compose run --rm --env DEPLOYMENT_BUILD_TAG=${<<TAG>>} node yarn build
+git checkout build/*-develop.json
+
+# Update CHANGELOG with new tag.
+nano CHANGELOG.md
+
+git add .
+git commit -m "Built release <<TAG>>"
+git push
+```
+
+
+
 ## Develop
 
 To enable easy development of templates, the supplied docker-compose setup serves a page where the

--- a/README.md
+++ b/README.md
@@ -7,21 +7,17 @@ See [https://github.com/os2display/display-docs/blob/main/templates.md](https://
 
 When creating a release the config files should be built with a tag in the config routes.
 
-Follow the instructions below.
+Follow the instructions below. Replace `<TAG>` with the given tag.
 
-Replace `<TAG>` with the given tag.
-
-```shell
-# Create the release branch: release/<TAG>
-
-# Build the js and config files with tags in main config files.
-docker compose run --rm --env DEPLOYMENT_BUILD_TAG=<TAG> node yarn build
-
-# Update CHANGELOG with the new tag.
-# When ready merge release branch in main.
-# Tag the release in main
-# Merge main in develop
-```
+1. Create the release branch: release/<TAG>
+2. Build the js and config files with tags in main config files.
+    ```shell
+    docker compose run --rm --env DEPLOYMENT_BUILD_TAG=<TAG> node yarn build
+    ```
+3. Update CHANGELOG with the new tag.
+4. When ready merge release branch in main.
+5. Tag the release in main
+6. Merge main in develop
 
 ## Develop
 
@@ -109,7 +105,7 @@ Override "main" base URL only:
 docker compose run --rm --env DEPLOYMENT_BUILD_BASE_URL_MAIN="http://$(docker compose port nginx 80)/build/" node yarn build
 ```
 
-The default behavoir is equivalent to
+The default behavior is equivalent to
 
 ```sh
 docker compose run --rm \

--- a/build/book-review-config-main.json
+++ b/build/book-review-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FP2SME0ENTXWF362XHM6Z1B4",
   "description": "Skabelon til anmeldelser.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/book-review.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/book-review-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/book-review-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/book-review.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/book-review-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/book-review-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/calendar-config-main.json
+++ b/build/calendar-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FRJPF4XATRN8PBZ35XN84PS6",
   "description": "Mulighed for at vise et kalenderfeed.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/calendar.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/calendar-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/calendar-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/calendar.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/calendar-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/calendar-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/contacts-config-main.json
+++ b/build/contacts-config-main.json
@@ -4,8 +4,8 @@
   "id": "01FPZ19YEHX7MQ5Q6ZS0WK0VEA",
   "description": "Skabelon til kontakter.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/contacts.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/contacts-admin.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/contacts.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/contacts-admin.json",
     "schema": "",
     "assets": [],
     "options": {},

--- a/build/iframe-config-main.json
+++ b/build/iframe-config-main.json
@@ -4,8 +4,8 @@
   "id": "01FQBJQ2M3544ZKAADPWBXHY71",
   "description": "Skabelon til iFrame.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/iframe.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/iframe-admin.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/iframe.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/iframe-admin.json",
     "schema": "",
     "assets": [],
     "options": {},

--- a/build/image-text-config-main.json
+++ b/build/image-text-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FP2SNGFN0BZQH03KCBXHKYHG",
   "description": "Mulighed for at sætte billede og tekst, med forskellige visninger.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/image-text.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/image-text-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/image-text-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/image-text.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/image-text-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/image-text-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/instagram-feed-config-main.json
+++ b/build/instagram-feed-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FTZC0RKJYHG4JVZG5K709G46",
   "description": "Mulighed for at vise instagram indhold.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/instagram-feed.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/instagram-feed-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/instagram-feed-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/instagram-feed.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/instagram-feed-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/instagram-feed-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/poster-config-main.json
+++ b/build/poster-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FWJZQ25A1868V63CWYYHQFKQ",
   "description": "Mulighed for at vise plakat indhold.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/poster.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/poster-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/poster-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/poster.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/poster-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/poster-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/rss-config-main.json
+++ b/build/rss-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FQC300GGWCA7A8H0SXY6P9FG",
   "description": "Mulighed for at vise et rss feed.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/rss.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/rss-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/rss-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/rss.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/rss-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/rss-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/slideshow-config-main.json
+++ b/build/slideshow-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FP2SNSC9VXD10ZKXQR819NS9",
   "description": "Skabelon til slideshow af billeder med forskellige effekter",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/slideshow.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/slideshow-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/slideshow-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/slideshow.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/slideshow-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/slideshow-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/table-config-main.json
+++ b/build/table-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FQBJFKM0YFX1VW5K94VBSNCP",
   "description": "Skabelon til tabel.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/table.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/table-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/table-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/table.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/table-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/table-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/travel-config-main.json
+++ b/build/travel-config-main.json
@@ -4,8 +4,8 @@
   "id": "01FZD7K807VAKZ99BGSSCHRJM6",
   "description": "Skabelon til rejseplanen.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/travel.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/travel-admin.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/travel.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/travel-admin.json",
     "schema": "",
     "assets": [],
     "options": {},

--- a/build/video-config-main.json
+++ b/build/video-config-main.json
@@ -4,9 +4,9 @@
   "id": "01FQBJFKM0YFX1VW5K94VBSNCC",
   "description": "Skabelon til video.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/video.js?ts=1723805672543",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/video-admin.json?ts=1723805672543",
-    "schema": "https://raw.githubusercontent.com/os2display/display-templates/main/build/video-schema.json?ts=1723805672543",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/video.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/video-admin.json",
+    "schema": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/video-schema.json",
     "assets": [],
     "options": {},
     "content": {}

--- a/build/vimeo-player-config-main.json
+++ b/build/vimeo-player-config-main.json
@@ -4,8 +4,8 @@
   "id": "01FQBJQ2M3544ZKAADPWBXHY17",
   "description": "Skabelon til Vimeo Video.",
   "resources": {
-    "component": "https://raw.githubusercontent.com/os2display/display-templates/main/build/vimeo-player.js?ts=1727091804576",
-    "admin": "https://raw.githubusercontent.com/os2display/display-templates/main/build/vimeo-player-admin.json?ts=1727091804576",
+    "component": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/vimeo-player.js",
+    "admin": "https://raw.githubusercontent.com/os2display/display-templates/refs/tags/2.1.1/build/vimeo-player-admin.json",
     "schema": "",
     "assets": [],
     "options": {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,21 +59,34 @@ const transformConfig = (type) => (content) => {
   const config = JSON.parse(content.toString());
 
   // Base build URL with trailing slash.
-  const baseUrl = (
-    type === "develop"
-      ? process.env.DEPLOYMENT_BUILD_BASE_URL_DEVELOP ??
-        process.env.DEPLOYMENT_BUILD_BASE_URL ??
-        "https://raw.githubusercontent.com/os2display/display-templates/develop/build/"
-      : process.env.DEPLOYMENT_BUILD_BASE_URL_MAIN ??
-        process.env.DEPLOYMENT_BUILD_BASE_URL ??
-        "https://raw.githubusercontent.com/os2display/display-templates/main/build/"
-  ).replace(/\/*$/, "/");
+  let baseUrl;
+
+  if (type === "develop") {
+    baseUrl =
+      process.env.DEPLOYMENT_BUILD_BASE_URL_DEVELOP ??
+      process.env.DEPLOYMENT_BUILD_BASE_URL ??
+      "https://raw.githubusercontent.com/os2display/display-templates/develop/build/";
+  } else if (process.env.DEPLOYMENT_BUILD_TAG) {
+    baseUrl = `https://raw.githubusercontent.com/os2display/display-templates/refs/tags/${process.env.DEPLOYMENT_BUILD_TAG}/build/`;
+  } else {
+    baseUrl =
+      process.env.DEPLOYMENT_BUILD_BASE_URL_MAIN ??
+      process.env.DEPLOYMENT_BUILD_BASE_URL ??
+      "https://raw.githubusercontent.com/os2display/display-templates/main/build/";
+  }
+
+  baseUrl.replace(/\/*$/, "/");
 
   const processPath = (processablePath) => {
     const buildPath = processablePath.replace(
       "https://display-templates.local.itkdev.dk/build/",
       ""
     );
+
+    if (process.env.DEPLOYMENT_BUILD_TAG) {
+      const url = new URL(buildPath, baseUrl);
+      return url.toString();
+    }
 
     try {
       const url = new URL(buildPath, baseUrl);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ const transformConfig = (type) => (content) => {
       ""
     );
 
-    if (process.env.DEPLOYMENT_BUILD_TAG) {
+    if (process.env.DEPLOYMENT_BUILD_TAG && type === "main") {
       const url = new URL(buildPath, baseUrl);
       return url.toString();
     }


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/3197

- Added tags to config routes to make it possible to target a release instead of newest main.

NB! Requires tagging as 2.1.1 after merge in main, since the files point to a non-existing release otherwise.