### PR TITLE
Fix BRND idraetsanlaeg Hvor column to use facility instead of area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fixed BRND `idraetsanlaeg` layout so the `Hvor` column now uses `facility` instead of `area`.
+
 - [#199](https://github.com/os2display/display-templates/pull/199)
   - Added `idraetsanlaeg` BRND layout with column order: Hvornår, Hvor, Hvad, Hvem, Bemærkninger.
   - Added KK-specific styling updates (dark header area, zebra-striped rows, centered date row, adjusted spacing/alignment).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Fixed BRND `idraetsanlaeg` layout so the `Hvor` column now uses `facility` instead of `area`.
+- [#201](https://github.com/os2display/display-templates/pull/201)
+  - Fixed BRND `idraetsanlaeg` layout so the `Hvor` column now uses `facility` instead of `area`.
 
 - [#199](https://github.com/os2display/display-templates/pull/199)
   - Added `idraetsanlaeg` BRND layout with column order: Hvornår, Hvor, Hvad, Hvem, Bemærkninger.

--- a/src/brnd/brnd-idraetsanlaeg.js
+++ b/src/brnd/brnd-idraetsanlaeg.js
@@ -112,7 +112,7 @@ function BrndIdraetsanlaeg({
                     rowIndex % 2 === 0 ? "row-even" : "row-odd"
                   }`}
                 >
-                  {getTitle(entry.area)}
+                  {getTitle(entry.facility)}
                 </ContentItem>
                 <ContentItem
                   className={`content-item content-item-activity ${


### PR DESCRIPTION
#### Link to ticket

Please add a link to the ticket being addressed by this change.

#### Description

Changed area to facility in "Hvor" column in the BRND Idrætsanlæg template.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
